### PR TITLE
Convert intraday and summary step count to Open mHealth step-count

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,26 @@
 Spring Boot microservice that converts data obtained from [Fitbit's Web API](https://dev.fitbit.com/build/reference/web-api/) into [Open mHealth](https://openmhealth.org) compliant JSON. Based on [Shimmer](https://github.com/openmhealth/shimmer).
 Currently supports intraday heart rate, intraday step count, and physical activity data.
 
-## Installation and Usage
+## Installation
 - Requires [JDK 11 or above](https://jdk.java.net/16/) installed.
 
 ### To build
-`./gradlew build`
+```
+./gradlew build
+```
 
 ### To run
-`./gradlew bootRun`
+```
+./gradlew bootRun
+```
 
-The application will run on `http://localhost:8080`
+The application will start on `http://localhost:8080` by default.
 
-### Converting Intraday Heart Rate
-Execute a **POST** request with body containing JSON obtained from the Fitbit Web API's [Get Heart Rate Time Series endpoint](https://dev.fitbit.com/build/reference/web-api/heart-rate/) to `/heart-rate`.
+## Usage
 
-### Converting Intraday Step Count
-Execute a **POST** request with body containing JSON obtained from the Fitbit Web API's [Get Activity Intraday Time Series endpoint](https://dev.fitbit.com/build/reference/web-api/activity/#activity-time-series)  to `/step-count`.
-
-### Converting Physical Activity
-Execute a **POST** request with body containing JSON obtained from the Fitbit Web API's [Get Daily Activity endpoint](https://dev.fitbit.com/build/reference/web-api/activity/)  to `/physical-activity`.
+| Endpoint  | Description  | Method  |  Body   |
+|---|---|---|---|
+| /heart-rate/intraday  | Converts Fitbit heart rate (intraday) to OMH heart-rate   | POST | JSON from [Get Heart Rate Time Series](https://dev.fitbit.com/build/reference/web-api/heart-rate/) endpoint   | 
+| /physical-activity  | Converts Fitbit daily activity summary to OMH [physical-activity](https://www.openmhealth.org/documentation/#/schema-docs/schema-library/schemas/omh_physical-activity)  | POST | JSON from [Get Daily Activity](https://dev.fitbit.com/build/reference/web-api/activity/) endpoint   |  
+| /step-count/summary  | Converts Fitbit step count (intraday) to OMH [step-count](https://www.openmhealth.org/documentation/#/schema-docs/schema-library/schemas/omh_step-count)   | POST | JSON from [Get Activity Intraday Time Series](https://dev.fitbit.com/build/reference/web-api/activity/#activity-time-series) endpoint  | 
+| /step-count/intraday | Converts Fitbit step count (summary) to OMH [step-count](https://www.openmhealth.org/documentation/#/schema-docs/schema-library/schemas/omh_step-count) | POST | JSON from [Get Activity Intraday Time Series](https://dev.fitbit.com/build/reference/web-api/activity/#activity-time-series) |

--- a/src/main/java/com/vishnuravi/fitbitOMH/controller/HeartRateController.java
+++ b/src/main/java/com/vishnuravi/fitbitOMH/controller/HeartRateController.java
@@ -16,8 +16,8 @@ public class HeartRateController {
     @Autowired
     private HeartRateService heartRateService;
 
-    @PostMapping
-    public List<DataPoint<HeartRate>> mapHeartRateToOMH(@RequestBody JsonNode jsonNode){
-        return heartRateService.mapHeartRate(jsonNode);
+    @PostMapping("/intraday")
+    public List<DataPoint<HeartRate>> mapIntradayHeartRateToOMH(@RequestBody JsonNode jsonNode){
+        return heartRateService.mapIntradayHeartRate(jsonNode);
     }
 }

--- a/src/main/java/com/vishnuravi/fitbitOMH/controller/HeartRateController.java
+++ b/src/main/java/com/vishnuravi/fitbitOMH/controller/HeartRateController.java
@@ -16,6 +16,11 @@ public class HeartRateController {
     @Autowired
     private HeartRateService heartRateService;
 
+    /**
+     * Converts Fitbit intraday heart rate to Open mHealth heart-rate
+     * @param jsonNode - JSON from Fitbit Web API
+     * @return A List of {@link HeartRate} data points
+     */
     @PostMapping("/intraday")
     public List<DataPoint<HeartRate>> mapIntradayHeartRateToOMH(@RequestBody JsonNode jsonNode){
         return heartRateService.mapIntradayHeartRate(jsonNode);

--- a/src/main/java/com/vishnuravi/fitbitOMH/controller/HomeController.java
+++ b/src/main/java/com/vishnuravi/fitbitOMH/controller/HomeController.java
@@ -8,6 +8,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/")
 public class HomeController {
 
+    /**
+     * Default welcome message
+     * @return String
+     */
     @GetMapping
     public String home(){
         return "Fitbit to Open mHealth converter is up and running.";

--- a/src/main/java/com/vishnuravi/fitbitOMH/controller/PhysicalActivityController.java
+++ b/src/main/java/com/vishnuravi/fitbitOMH/controller/PhysicalActivityController.java
@@ -19,6 +19,11 @@ public class PhysicalActivityController {
     @Autowired
     private PhysicalActivityService physicalActivityService;
 
+    /**
+     * Converts Fitbit daily activity summary to Open mHealth physical-activity
+     * @param jsonNode - JSON from Fitbit Web API
+     * @return A List of {@link PhysicalActivity} data points
+     */
     @PostMapping
     public List<DataPoint<PhysicalActivity>> mapPhysicalActivityToOMH(@RequestBody JsonNode jsonNode){
         return physicalActivityService.mapPhysicalActivity(jsonNode);

--- a/src/main/java/com/vishnuravi/fitbitOMH/controller/StepCountController.java
+++ b/src/main/java/com/vishnuravi/fitbitOMH/controller/StepCountController.java
@@ -19,11 +19,21 @@ public class StepCountController {
     @Autowired
     private StepCountService stepCountService;
 
+    /**
+     * Converts Fitbit step count to Open mHealth step-count
+     * @param jsonNode - JSON from Fitbit Web API
+     * @return A List of {@link StepCount2} data points
+     */
     @PostMapping("/summary")
     public List<DataPoint<StepCount2>> mapStepCountToOMH(@RequestBody JsonNode jsonNode){
         return stepCountService.mapStepCount(jsonNode);
     }
 
+    /**
+     * Converts Fitbit intraday step count data to Open mHealth step-count
+     * @param jsonNode - JSON from Fitbit API
+     * @return A List of {@link StepCount2} data points
+     */
     @PostMapping("/intraday")
     public List<DataPoint<StepCount2>> mapIntradayStepCountToOMH(@RequestBody JsonNode jsonNode){
         return stepCountService.mapIntradayStepCount(jsonNode);

--- a/src/main/java/com/vishnuravi/fitbitOMH/controller/StepCountController.java
+++ b/src/main/java/com/vishnuravi/fitbitOMH/controller/StepCountController.java
@@ -19,9 +19,14 @@ public class StepCountController {
     @Autowired
     private StepCountService stepCountService;
 
-    @PostMapping
+    @PostMapping("/summary")
     public List<DataPoint<StepCount2>> mapStepCountToOMH(@RequestBody JsonNode jsonNode){
         return stepCountService.mapStepCount(jsonNode);
+    }
+
+    @PostMapping("/intraday")
+    public List<DataPoint<StepCount2>> mapIntradayStepCountToOMH(@RequestBody JsonNode jsonNode){
+        return stepCountService.mapIntradayStepCount(jsonNode);
     }
 
 }

--- a/src/main/java/com/vishnuravi/fitbitOMH/service/HeartRateService.java
+++ b/src/main/java/com/vishnuravi/fitbitOMH/service/HeartRateService.java
@@ -15,10 +15,15 @@ public class HeartRateService {
     @Autowired
     public HeartRateService(){
     }
-    
+
+    /**
+     * Converts a list of Fitbit intraday heart rate data points to Open mHealth heart-rate using {@link FitbitIntradayHeartRateDataPointMapper}.
+     * @param jsonNode - JSON from Fitbit Web API
+     * @return A list of {@link HeartRate} data points
+     */
     public List<DataPoint<HeartRate>> mapIntradayHeartRate(JsonNode jsonNode){
 
-        // Get granularity from JSON
+        // Get granularity interval and units from JSON
         Integer intradayDataGranularityInterval = jsonNode.get("activities-heart-intraday").get("datasetInterval").asInt();
         String intradayDataGranularityUnits = jsonNode.get("activities-heart-intraday").get("datasetType").asText();
 

--- a/src/main/java/com/vishnuravi/fitbitOMH/service/HeartRateService.java
+++ b/src/main/java/com/vishnuravi/fitbitOMH/service/HeartRateService.java
@@ -15,8 +15,8 @@ public class HeartRateService {
     @Autowired
     public HeartRateService(){
     }
-
-    public List<DataPoint<HeartRate>> mapHeartRate(JsonNode jsonNode){
+    
+    public List<DataPoint<HeartRate>> mapIntradayHeartRate(JsonNode jsonNode){
 
         // Get granularity from JSON
         Integer intradayDataGranularityInterval = jsonNode.get("activities-heart-intraday").get("datasetInterval").asInt();

--- a/src/main/java/com/vishnuravi/fitbitOMH/service/PhysicalActivityService.java
+++ b/src/main/java/com/vishnuravi/fitbitOMH/service/PhysicalActivityService.java
@@ -16,6 +16,11 @@ public class PhysicalActivityService {
     public PhysicalActivityService(){
     }
 
+    /**
+     * Converts Fitbit daily activity summary to Open mHealth physical-activity using {@link FitbitPhysicalActivityDataPointMapper}.
+     * @param jsonNode - JSON from Fitbit Web API
+     * @return A List of {@link PhysicalActivity} data points
+     */
     public List<DataPoint<PhysicalActivity>> mapPhysicalActivity(JsonNode jsonNode){
         FitbitPhysicalActivityDataPointMapper dataPointMapper = new FitbitPhysicalActivityDataPointMapper();
         return dataPointMapper.asDataPoints(jsonNode);

--- a/src/main/java/com/vishnuravi/fitbitOMH/service/StepCountService.java
+++ b/src/main/java/com/vishnuravi/fitbitOMH/service/StepCountService.java
@@ -14,14 +14,24 @@ import java.util.List;
 public class StepCountService {
 
     @Autowired
-    public StepCountService(){
-    }
+    public StepCountService(){ }
 
+    /**
+     * Converts Fitbit daily step counts to Open mHealth step-count using {@link FitbitStepCountDataPointMapper}.
+     * @param jsonNode - JSON from the Fitbit Web API
+     * @return A List of {@link StepCount2} data points
+     */
     public List<DataPoint<StepCount2>> mapStepCount(JsonNode jsonNode){
         FitbitStepCountDataPointMapper dataPointMapper = new FitbitStepCountDataPointMapper();
         return dataPointMapper.asDataPoints(jsonNode);
     }
 
+    /**
+     *
+     * Converts Fitbit intraday step counts into Open mHealth step-count using {@link FitbitIntradayStepCountDataPointMapper}.
+     * @param jsonNode - JSON from the Fitbit Web API
+     * @return A List of {@link StepCount2} data points
+     */
     public List<DataPoint<StepCount2>> mapIntradayStepCount(JsonNode jsonNode){
 
         // Get granularity from JSON

--- a/src/main/java/com/vishnuravi/fitbitOMH/service/StepCountService.java
+++ b/src/main/java/com/vishnuravi/fitbitOMH/service/StepCountService.java
@@ -2,6 +2,7 @@ package com.vishnuravi.fitbitOMH.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.openmhealth.mapper.fitbit.FitbitIntradayStepCountDataPointMapper;
+import org.openmhealth.mapper.fitbit.FitbitStepCountDataPointMapper;
 import org.openmhealth.schema.domain.omh.DataPoint;
 import org.openmhealth.schema.domain.omh.StepCount2;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,6 +18,11 @@ public class StepCountService {
     }
 
     public List<DataPoint<StepCount2>> mapStepCount(JsonNode jsonNode){
+        FitbitStepCountDataPointMapper dataPointMapper = new FitbitStepCountDataPointMapper();
+        return dataPointMapper.asDataPoints(jsonNode);
+    }
+
+    public List<DataPoint<StepCount2>> mapIntradayStepCount(JsonNode jsonNode){
 
         // Get granularity from JSON
         Integer intradayDataGranularityInterval = jsonNode.get("activities-steps-intraday").get("datasetInterval").asInt();
@@ -25,4 +31,5 @@ public class StepCountService {
         FitbitIntradayStepCountDataPointMapper dataPointMapper = new FitbitIntradayStepCountDataPointMapper(intradayDataGranularityInterval, intradayDataGranularityUnits);
         return dataPointMapper.asDataPoints(jsonNode);
     }
+
 }

--- a/src/main/java/org/openmhealth/mapper/fitbit/FitbitDataPointMapper.java
+++ b/src/main/java/org/openmhealth/mapper/fitbit/FitbitDataPointMapper.java
@@ -44,6 +44,9 @@ import static org.openmhealth.mapper.common.JsonNodeMappingSupport.asRequiredNod
  *
  * @author Chris Schaefbauer
  * @author Emerson Farrugia
+ *
+ * Modified by Vishnu Ravi (2021)
+ *
  */
 public abstract class FitbitDataPointMapper<T extends SchemaSupport> implements JsonNodeDataPointMapper<T> {
 

--- a/src/main/java/org/openmhealth/mapper/fitbit/FitbitIntradayDataPointMapper.java
+++ b/src/main/java/org/openmhealth/mapper/fitbit/FitbitIntradayDataPointMapper.java
@@ -34,15 +34,15 @@ import static org.openmhealth.mapper.common.JsonNodeMappingSupport.*;
 
 
 /**
- * TODO add Javadoc
  *
  * @author Chris Schaefbauer
  * @author Emerson Farrugia
  *
+ * Modified by Vishnu Ravi (2021)
+ *
  */
 public abstract class FitbitIntradayDataPointMapper<T extends SchemaSupport> extends FitbitDataPointMapper<T> {
 
-    // FIXME this shared state is a critical section if the mapper is reused
     private JsonNode responseNode;
     private Integer intradayDataGranularityInterval;
     private DurationUnit intradayDataGranularityUnits;
@@ -53,6 +53,11 @@ public abstract class FitbitIntradayDataPointMapper<T extends SchemaSupport> ext
         this.intradayDataGranularityUnits = intradayGranularityUnitsToDurationUnit(intradayDataGranularityUnits);
     }
 
+    /**
+     * Converts string representation of units of granularity (e.g. "minute", "second") to {@link DurationUnit} types
+     * @param intradayDataGranularityUnits
+     * @return {@link DurationUnit}
+     */
     private DurationUnit intradayGranularityUnitsToDurationUnit(String intradayDataGranularityUnits) {
         switch(intradayDataGranularityUnits){
             case "day": return DAY;

--- a/src/main/java/org/openmhealth/mapper/fitbit/FitbitIntradayDataPointMapper.java
+++ b/src/main/java/org/openmhealth/mapper/fitbit/FitbitIntradayDataPointMapper.java
@@ -38,6 +38,7 @@ import static org.openmhealth.mapper.common.JsonNodeMappingSupport.*;
  *
  * @author Chris Schaefbauer
  * @author Emerson Farrugia
+ *
  */
 public abstract class FitbitIntradayDataPointMapper<T extends SchemaSupport> extends FitbitDataPointMapper<T> {
 

--- a/src/main/java/org/openmhealth/mapper/fitbit/FitbitIntradayHeartRateDataPointMapper.java
+++ b/src/main/java/org/openmhealth/mapper/fitbit/FitbitIntradayHeartRateDataPointMapper.java
@@ -33,6 +33,7 @@ import static org.openmhealth.mapper.common.JsonNodeMappingSupport.asRequiredBig
  *
  * @author Wallace Wadge
  * @see <a href="https://dev.fitbit.com/docs/heart-rate/#get-heart-rate-intraday-time-series">API documentation</a>
+ *
  */
 public class FitbitIntradayHeartRateDataPointMapper extends FitbitIntradayDataPointMapper<HeartRate> {
 

--- a/src/main/java/org/openmhealth/mapper/fitbit/FitbitIntradayHeartRateDataPointMapper.java
+++ b/src/main/java/org/openmhealth/mapper/fitbit/FitbitIntradayHeartRateDataPointMapper.java
@@ -34,6 +34,8 @@ import static org.openmhealth.mapper.common.JsonNodeMappingSupport.asRequiredBig
  * @author Wallace Wadge
  * @see <a href="https://dev.fitbit.com/docs/heart-rate/#get-heart-rate-intraday-time-series">API documentation</a>
  *
+ * Modified by Vishnu Ravi (2021)
+ *
  */
 public class FitbitIntradayHeartRateDataPointMapper extends FitbitIntradayDataPointMapper<HeartRate> {
 

--- a/src/main/java/org/openmhealth/mapper/fitbit/FitbitIntradayStepCountDataPointMapper.java
+++ b/src/main/java/org/openmhealth/mapper/fitbit/FitbitIntradayStepCountDataPointMapper.java
@@ -33,6 +33,9 @@ import static org.openmhealth.mapper.common.JsonNodeMappingSupport.asRequiredBig
  *
  * @author Chris Schaefbauer
  * @see <a href="https://dev.fitbit.com/docs/activity/#get-activity-intraday-time-series">API documentation</a>
+ *
+ * Modified by Vishnu Ravi (2021)
+ *
  */
 public class FitbitIntradayStepCountDataPointMapper extends FitbitIntradayDataPointMapper<StepCount2> {
 

--- a/src/main/java/org/openmhealth/mapper/fitbit/FitbitPhysicalActivityDataPointMapper.java
+++ b/src/main/java/org/openmhealth/mapper/fitbit/FitbitPhysicalActivityDataPointMapper.java
@@ -37,6 +37,9 @@ import static org.openmhealth.mapper.common.JsonNodeMappingSupport.*;
  *
  * @author Chris Schaefbauer
  * @see <a href="https://dev.fitbit.com/docs/activity/#get-daily-activity-summary">API documentation</a>
+ *
+ * Modified by Vishnu Ravi (2021)
+ *
  */
 public class FitbitPhysicalActivityDataPointMapper extends FitbitDataPointMapper<PhysicalActivity> {
 

--- a/src/main/java/org/openmhealth/mapper/fitbit/FitbitStepCountDataPointMapper.java
+++ b/src/main/java/org/openmhealth/mapper/fitbit/FitbitStepCountDataPointMapper.java
@@ -35,7 +35,9 @@ import static org.openmhealth.mapper.common.JsonNodeMappingSupport.*;
  *
  * @author Chris Schaefbauer
  * @author Emerson Farrugia
- * 
+ *
+ * Modified by Vishnu Ravi (2021)
+ *
  */
 public class FitbitStepCountDataPointMapper extends FitbitDataPointMapper<StepCount2> {
 

--- a/src/main/java/org/openmhealth/mapper/fitbit/FitbitStepCountDataPointMapper.java
+++ b/src/main/java/org/openmhealth/mapper/fitbit/FitbitStepCountDataPointMapper.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017 Open mHealth
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openmhealth.mapper.fitbit;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.openmhealth.schema.domain.omh.DataPoint;
+import org.openmhealth.schema.domain.omh.DurationUnitValue;
+import org.openmhealth.schema.domain.omh.StepCount2;
+import org.openmhealth.schema.domain.omh.TimeInterval;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+import static org.openmhealth.schema.domain.omh.DurationUnit.DAY;
+import static org.openmhealth.mapper.common.JsonNodeMappingSupport.*;
+
+
+/**
+ * A mapper from Fitbit Resource API <code>activities/date</code> responses to {@link StepCount2} objects.
+ *
+ * @author Chris Schaefbauer
+ * @author Emerson Farrugia
+ * 
+ */
+public class FitbitStepCountDataPointMapper extends FitbitDataPointMapper<StepCount2> {
+
+    /**
+     * @return the name of the list node returned from the activities/steps Fitbit endpoint
+     */
+    @Override
+    protected String getListNodeName() {
+        return "activities-steps";
+    }
+
+    @Override
+    protected Optional<DataPoint<StepCount2>> asDataPoint(JsonNode node) {
+
+        Integer stepCountValue = asRequiredInteger(node, "value");
+
+        if (stepCountValue == 0) {
+            return Optional.empty();
+        }
+
+        LocalDate effectiveLocalDate = asRequiredLocalDate(node, "dateTime");
+
+        OffsetDateTime effectiveStartDateTime = asOffsetDateTimeWithFakeUtcTimeZone(effectiveLocalDate.atStartOfDay());
+
+        TimeInterval effectiveTimeInterval =
+                TimeInterval.ofStartDateTimeAndDuration(effectiveStartDateTime, new DurationUnitValue(DAY, 1));
+
+        StepCount2 measure = new StepCount2.Builder(stepCountValue, effectiveTimeInterval).build();
+
+        Optional<Long> externalId = asOptionalLong(node, "logId");
+
+        return Optional.of(newDataPoint(measure, externalId.orElse(null)));
+    }
+}


### PR DESCRIPTION
- Creates separate endpoints for converting step count intraday `/step-count/intraday` and summary `/step-count/summary` data from Fitbit to Open mHealth.
- Updates the `/heart-rate` endpoint, which handles Fitbit heart rate intraday data, to `/heart-rate/intraday` for consistency with the above.
- Adds JavaDocs