### PR TITLE
added devcontainer and cloudbuild support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,29 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.191.0/containers/java/.devcontainer/base.Dockerfile
+# [Choice] Java version: 8, 11, 16
+ARG VARIANT=11
+FROM mcr.microsoft.com/vscode/devcontainers/java:0-${VARIANT}
+
+# [Option] Install Maven
+ARG INSTALL_MAVEN="false"
+ARG MAVEN_VERSION=""
+# [Option] Install Gradle
+ARG INSTALL_GRADLE="false"
+ARG GRADLE_VERSION=""
+RUN if [ "${INSTALL_MAVEN}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/sdkman/bin/sdkman-init.sh && sdk install maven \"${MAVEN_VERSION}\""; fi \
+    && if [ "${INSTALL_GRADLE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/sdkman/bin/sdkman-init.sh && sdk install gradle \"${GRADLE_VERSION}\""; fi
+
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
+ARG NODE_VERSION="none"
+RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends google-cloud-sdk dcmtk curl
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment this line to install global node packages.
+# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,41 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.191.0/containers/java
+{
+	"name": "Java",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			// Update the VARIANT arg to pick a Java version: 8, 11, 14
+			"VARIANT": "11",
+			// Options
+			"INSTALL_MAVEN": "true",
+			"MAVEN_VERSION": "3.6.3",
+			"INSTALL_GRADLE": "true",
+			"NODE_VERSION": "lts/*"
+		}
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+		"java.home": "/docker-java-home",
+		"maven.executable.path": "/usr/local/sdkman/candidates/maven/current/bin/mvn"
+	},
+	
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"vscjava.vscode-java-pack"
+	],
+
+	"mounts": [
+		"source=${env:HOME}${env:USERPROFILE}/.config,target=/home/vscode/.config,type=bind"
+	],
+	
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "java -version",
+
+	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
+}

--- a/README.md
+++ b/README.md
@@ -45,3 +45,6 @@ docker push gcr.io/\[gcp-project\]/fitbit2openmhealth:v1.0
 
 gcloud beta run deploy --image gcr.io/\[gcp-project\]/fitbit2openmhealth:v1.0 
 
+## To build using google cloud builder
+gcloud builds submit --config cloud-build.yml
+

--- a/cloud-build.yml
+++ b/cloud-build.yml
@@ -1,0 +1,10 @@
+steps:
+- name: gradle:7.2-jdk11
+  entrypoint: gradle
+  args: ['test']
+- name: gradle:7.2-jdk11
+  entrypoint: gradle
+  args: ['assemble']
+- name: gcr.io/cloud-builders/docker
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/fitbit2openmhealth', '--build-arg=JAR_FILE=build/libs/fitbitOMH-0.0.1-SNAPSHOT.jar', '.']
+images: ['gcr.io/$PROJECT_ID/fitbit2openmhealth']


### PR DESCRIPTION
devcontainer for vscode specifies a container in which to develop so the developer does not need to install java, gradle, etc in order to build.

cloudbuild is a google cloud service that does automated remote builds.  in this case, it builds the container and registers it with gcr so the dev does not need to have docker installed locally.